### PR TITLE
Feature/fix backward in 6 7 Исправление поведения по кнопке назад и последовательном вводе 6 и 7.

### DIFF
--- a/vkbot.py
+++ b/vkbot.py
@@ -141,11 +141,22 @@ class VKBot:
     def __check_for_service_event(self, user_id, text):
         """Метод проверки события, и записи в словарь."""
         if text in ["6", "7"]:
-            self.__temp_data.setdefault(user_id, text + "_for_adm")
+            # В случае если, пользователь ввёл пункты 6 и 7 без ввода текста,
+            # устанавливаем ожидание сообщение по последнему такому пункту.
+            self.__temp_data[user_id] = text + "_for_adm"
 
     def __read_menu_handler(self, user_id, text):
         """Обработка команд для чтения меню."""
         if self.__cmd_answ.get(text) is not None:
+            # Если пришли команды Назад, Начать или Меню
+            if text in (
+                BACKWARD_BUTTON_LABEL,
+                START_BUTTON_LABEL,
+                MENU_BUTTON_LABEL,
+            ):
+                # стираем ожидание сообщений по п. 6 и 7,
+                # если такое было сохранено
+                self.__temp_data.pop(user_id, None)
             self.__send_message(user_id, *self.__cmd_answ.get(text))
         elif self.__menu.get_message_by_index(text) is not None:
             self.__send_message(
@@ -169,6 +180,8 @@ class VKBot:
         else:
             self.__send_message(user_id, *self.__cmd_answ[START_BUTTON_LABEL])
             self.__send_message(user_id, *self.__cmd_answ[MENU_BUTTON_LABEL])
+            # Стираем ожидание текста по п. 6 и 7, если такое было сохранено.
+            self.__temp_data.pop(user_id, None)
 
     def __get_user_name(self, user_id):
         """Метод получения данных пользователя по id."""


### PR DESCRIPTION
Найдено неожиданное поведение бота.
Описание проблемы 1:
Вводим команду 6 или 7.
Нажимаем Назад.
Получаем приветствие.
Вводим текст.
Текст уходит админу и пользователь получает сообщение в соответствии с пунктами 6 или 7.
А должно быть приветствие.

Описание проблемы 2:
Вводим команду 6 (запрос обратной связи)
Нажимаем кнопку Назад (получаем приветствие)
Вводим пункт 7
(или вводим пункт 7 с клавиатуры без кнопки назад)
Получаем сообщение по пункту 7.
Вводим Свой вопрос.
Администратору и пользователю уходят сообщения как для обратной связи, т.е. пункту 6. 
(аналогичная проблема если поменять пункты 6 и 7 местами).
А должны быть сообщения по вопросу - пункт 7.

Предложения по исправлению в методе VKBot.__read_menu_handler(...) и self.__check_for_service_event(...).
