### PR TITLE
Fix/fix backward 6 7 mix with edit menu

### DIFF
--- a/vkbot.py
+++ b/vkbot.py
@@ -141,14 +141,14 @@ class VKBot:
     def __check_for_service_event(self, user_id, text):
         """Метод проверки события, и записи в словарь."""
         if text in ["6", "7"]:
-            self.__temp_data.setdefault(user_id, text + "_for_adm")
+            self.__temp_data[user_id] = text + "_for_adm"
 
     def __read_menu_handler(self, user_id, text):
         """Обработка команд для чтения меню."""
         if self.__cmd_answ.get(text) is not None:
             self.__send_message(user_id, *self.__cmd_answ.get(text))
-            if user_id in self.__temp_data:
-                self.__temp_data.pop(user_id)
+            # В случае смешанных команд
+            self.__temp_data.pop(user_id, None)
         elif self.__menu.get_message_by_index(text) is not None:
             self.__send_message(
                 user_id,
@@ -425,6 +425,8 @@ class VKBot:
             # Если ввод текста не соответствует текущей стадии режима
             # редактирования, или поступили смешанные команды, то
             # сброс параметров редактирования, команда не обработана.
+            if self.__menu_edit_mode:
+                self.__temp_data.pop(user_id, None)
             self.__drop_edit_values()
 
     def __cancel_from_edit_mode_handler(self, **kwargs):

--- a/vkbot.py
+++ b/vkbot.py
@@ -147,6 +147,8 @@ class VKBot:
         """Обработка команд для чтения меню."""
         if self.__cmd_answ.get(text) is not None:
             self.__send_message(user_id, *self.__cmd_answ.get(text))
+            if user_id in self.__temp_data:
+                self.__temp_data.pop(user_id)
         elif self.__menu.get_message_by_index(text) is not None:
             self.__send_message(
                 user_id,

--- a/vkbot.py
+++ b/vkbot.py
@@ -142,6 +142,8 @@ class VKBot:
         """Метод проверки события, и записи в словарь."""
         if text in ["6", "7"]:
             self.__temp_data[user_id] = text + "_for_adm"
+        else:
+            self.__temp_data.pop(user_id, None)
 
     def __read_menu_handler(self, user_id, text):
         """Обработка команд для чтения меню."""


### PR DESCRIPTION
Найдено неожиданное поведение бота.
Описание проблемы 1:
Вводим команду 6 или 7.
Нажимаем Назад.
Получаем приветствие.
Вводим текст.
Текст уходит админу и пользователь получает сообщение в соответствии с пунктами 6 или 7.
А должно быть приветствие.

Описание проблемы 2:
Вводим команду 6 (запрос обратной связи)
Нажимаем кнопку Назад (получаем приветствие)
Вводим пункт 7
(или вводим пункт 7 с клавиатуры без кнопки назад)
Получаем сообщение по пункту 7.
Вводим Свой вопрос.
Администратору и пользователю уходят сообщения как для обратной связи, т.е. пункту 6.
(аналогичная проблема если поменять пункты 6 и 7 местами).
А должны быть сообщения по вопросу - пункт 7.

Описание проблемы 3:
Вводим команду 6 (запрос обратной связи) или 7.
Вводим edit menu
Вводим текст.
Администратору и пользователю уходят сообщения как для обратной связи, т.е. пункту 6.
А должно быть приветствие.

Описание проблемы 4:
Вводим 6 или 7
Вводим 1, 2,…, 5.
Вводим текст.
Администратору и пользователю уходят сообщения как для обратной связи, т.е. пункту 6.
А должно быть приветствие.

Предложения по исправлению в методе VKBot.__read_menu_handler(...) и self.__check_for_service_event(…), __receive_new_value_handler
